### PR TITLE
docker-compose version bump and cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,9 @@
-version: '2'
+version: '3'
 
 services:
   pritunl:
     image: 'jippi/pritunl:latest'
-    labels:
-      kompose.service.type: nodeport
     privileged: true
-    network_mode: host
     ports:
       - '80:80'
       - '443:443'
@@ -15,6 +12,7 @@ services:
     volumes:
       - 'pritunl_data:/var/lib/pritunl'
       - 'pritunl_db:/var/lib/mongodb'
+
 volumes:
   pritunl_data:
     driver: local


### PR DESCRIPTION
- bumped version to 3, should just work with any recent docker-compose
- removed the komposer label, kubernetes specific.
- I removed the `network: host` property. It is not necessary, and in fact the `docker run` example in the README.MD isn't using it. Using `network: host` binds all exposed ports directly on the docker host. I am not sure how well the bundled mongodb server is secured, but you probably shouldn't just expose it over the network for no reason.